### PR TITLE
Fix GoReleaser flags

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
-          version: latest
-          args: release --rm-dist
+          version: v2
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CGO_ENABLED: 0


### PR DESCRIPTION
This pull request updates the GoReleaser step in the GitHub Actions workflow to use a specific version and changes the release arguments for improved reliability and clarity.

GoReleaser action update:

* Updated the GoReleaser version from `latest` to `v2` and changed the release arguments from `--rm-dist` to `--clean` in `.github/workflows/tagpr.yml` for more predictable builds and cleanup.